### PR TITLE
Adapta as variáveis do CSS à nova versão do tema dez (2.0)

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         1.8.4
+ * Version:         1.8.5
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define plugin version constant
  */
-define( 'ORBITA_VERSION', '1.8.4' );
+define( 'ORBITA_VERSION', '1.8.5' );
 
 /**
  * Enqueue style file

--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         1.8.5
+ * Version:         1.8.4
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define plugin version constant
  */
-define( 'ORBITA_VERSION', '1.8.5' );
+define( 'ORBITA_VERSION', '1.8.4' );
 
 /**
  * Enqueue style file

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -122,7 +122,7 @@ $desktop: "only screen and (min-width : 700px)";
   .options {
     font-size: 80%;
     filter: grayscale(1);
-    color: #a6a6a6;
+    color: #535353;
     margin-left: 6px;
     a {
       display: inline-block;
@@ -131,7 +131,7 @@ $desktop: "only screen and (min-width : 700px)";
   .domain {
     font-size: 80%;
     margin-left: 6px;
-    color: #a6a6a6;
+    color: #535353;
     display: inline-block;
   }
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -42,9 +42,8 @@ $desktop: "only screen and (min-width : 700px)";
     }
     .count {
       z-index: 1;
-      font-size: var(--small);
-      color: #a6a6a6;
-      margin-top: -8px;
+      font-size: var(--fs-0);
+      margin-top: -6px;
       position: relative;
     }
   }
@@ -82,7 +81,7 @@ $desktop: "only screen and (min-width : 700px)";
     .data {
       margin-top: 6px;
       font-family: monospace;
-      font-size: var(--small);
+      font-size: var(--fs-0);
       .comments {
         filter: grayscale(1);
         font-size: 100%;
@@ -158,7 +157,7 @@ $desktop: "only screen and (min-width : 700px)";
 .orbita-header {
   width: 100%;
   margin-bottom: 2rem;
-  background-color: var(--cor-de-fundo);
+  background-color: var(--cor-caixas);
   padding: 0.5rem 0;
   border-radius: var(--borda-curva);
   display: flex;
@@ -173,14 +172,6 @@ $desktop: "only screen and (min-width : 700px)";
     a {
       margin: 0 .3rem;
       
-      &:visited {
-        color: var(--color-link);
-      }
-  
-      &:hover {
-        color: var(--color-link-states);
-      }
-  
       @media #{$desktop} {
         margin: 0 0 0 1rem;
       }
@@ -235,21 +226,14 @@ $desktop: "only screen and (min-width : 700px)";
     }
   }
 
-  input[type="url"] {
-    background-color: var(--light-bg);
-    color: var(--txt-color);
-    border: 1px solid var(--border-color);
-  }
-
   textarea {
-    max-width: 60ch;
-    background-color: var(--light-bg);
+    max-width: var(--line-length);
   }
 
   .orbita-help-block {
     font-family: monospace;
     display: block;
-    font-size: var(--small);
+    font-size: var(--fs-0);
   }
 
   .orbita-post-title {


### PR DESCRIPTION
**Ao abrir um Pull Request, marque com um X cada um dos items do checklist abaixo.**

### Checklist
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 14 (` * Version:         1.x.x`)
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 43 (`define( 'ORBITA_VERSION', '1.x.x' );`)

### Descrição

O plugin usa algumas variáveis do CSS importadas do tema dez. Hoje [subi uma atualização](https://github.com/manualdousuario/dez/pull/8) e, nela, padronizei as variáveis, o que deixou o Órbita “quebrado”.

Aproveitei o embalo para remover algumas classes desnecessárias (decoração de formulários, por exemplo) e ajustar algumas cores que não estava com contraste suficiente.