### PR TITLE
Adiciona atributo “async” ao JavaScript do Órbita

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         1.8.8
+ * Version:         1.8.9
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define plugin version constant
  */
-define( 'ORBITA_VERSION', '1.8.7' );
+define( 'ORBITA_VERSION', '1.8.9' );
 
 /**
  * Enqueue style file
@@ -62,6 +62,7 @@ function orbita_enqueue_scripts() {
 		array(
 			'restURL'   => rest_url(),
 			'restNonce' => wp_create_nonce( 'wp_rest' ),
+			'strategy'  => 'async',
 		)
 	);
 }


### PR DESCRIPTION
### Checklist
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 14 (` * Version:         1.x.x`)
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 43 (`define( 'ORBITA_VERSION', '1.x.x' );`)

### Descrição

Aproveitando [este recurso](https://make.wordpress.org/core/2023/07/14/registering-scripts-with-async-and-defer-attributes-in-wordpress-6-3/) introduzido no WordPress 6.3. Creio que `async` seja melhor que `defer` neste caso; corrijam-me se eu estiver enganado.