### PR TITLE
Corrige erro no elemento `.orbita-header label`

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         1.8.9
+ * Version:         1.8.10
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define plugin version constant
  */
-define( 'ORBITA_VERSION', '1.8.9' );
+define( 'ORBITA_VERSION', '1.8.10' );
 
 /**
  * Enqueue style file

--- a/public/main.css
+++ b/public/main.css
@@ -165,7 +165,7 @@
 .orbita-header div a:hover {
   color: var(--color-link-states);
 }
-.orbita-header .orbita-header label {
+.orbita-header label {
   margin: 0;
 }
 .orbita-header .telegram img,

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -182,7 +182,7 @@ $desktop: "only screen and (min-width : 700px)";
     }
   }
 
-  .orbita-header label {
+  label {
     margin: 0;
   }
 


### PR DESCRIPTION
### Checklist
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 14 (` * Version:         1.x.x`)
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 43 (`define( 'ORBITA_VERSION', '1.x.x' );`)

### Descrição

Cometi um errinho no `main.scss` que fez com que a impressão saísse assim: `.orbita-header .orbita-header label`.