### PR TITLE
Corrige inclusão do atributo async ao puxar `main.min.js`

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         1.8.10
+ * Version:         1.9
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define plugin version constant
  */
-define( 'ORBITA_VERSION', '1.8.10' );
+define( 'ORBITA_VERSION', '1.9' );
 
 /**
  * Enqueue style file
@@ -55,14 +55,13 @@ add_action( 'wp_enqueue_scripts', 'orbita_enqueue_styles' );
  * Enqueue script file
  */
 function orbita_enqueue_scripts() {
-	wp_register_script( 'orbita', plugins_url( '/public/main.min.js', __FILE__ ), array(), ORBITA_VERSION, true );
+	wp_register_script( 'orbita', plugins_url( '/public/main.min.js', __FILE__ ), array(), ORBITA_VERSION, array( 'strategy' => 'async' ) );
 	wp_localize_script(
 		'orbita',
 		'orbitaApi',
 		array(
 			'restURL'   => rest_url(),
 			'restNonce' => wp_create_nonce( 'wp_rest' ),
-			'strategy'  => 'async',
 		)
 	);
 }


### PR DESCRIPTION
### Checklist
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 14 (` * Version:         1.x.x`)
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 43 (`define( 'ORBITA_VERSION', '1.x.x' );`)

### Descrição

A implementação original, no branch `script-async`, estava errada/não funcionando. Dei uma fuçada aqui e, agora sim, está puxando certo.

Tive que remover um `true` da chamada (`wp_register_script`) para funcionar. A princípio, não notei problema algum. Verifiquem, por favor.