### PR TITLE
Corrige um erro crítico no `single-orbita.php`

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         1.9.4
+ * Version:         1.9.5
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define plugin version constant
  */
-define( 'ORBITA_VERSION', '1.9.4' );
+define( 'ORBITA_VERSION', '1.9.5' );
 
 /**
  * Enqueue style file

--- a/single-orbita.php
+++ b/single-orbita.php
@@ -94,7 +94,7 @@ get_header();
 		</article>
 			<?php
 			// If comments are open or we have at least one comment, load up the comment template.
-			if ( comments_open() || get_comments_number() ) : ?
+			if ( comments_open() || get_comments_number() ) :
 				comments_template();
 			endif;
 


### PR DESCRIPTION
Sobrou um `?` na função que chama os comentários. (Aliás, no 1.9.3 eu removi a mensagem duplicada no form de comentários. Esqueci de mencionar no commit.)

Sem pressa para gerar a nova versão. Corrigi em produção mesmo, na 1.9.4.

**Ao abrir um Pull Request, marque com um X cada um dos items do checklist abaixo.**

### Checklist
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 14 (` * Version:         1.x.x`)
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 43 (`define( 'ORBITA_VERSION', '1.x.x' );`)