### PR TITLE
Função para enviar imagens as postagens

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -775,7 +775,7 @@ function orbita_form_shortcode() {
 			$html = 'Para postar links ou iniciar conversas na Órbita, <a href="' . wp_login_url( home_url( '/orbita/postar' ) ) . '">faça login</a> ou <a href="' . wp_registration_url() . '">cadastre-se gratuitamente</a>.';
 		}
 		if( $orbita_error == 'invalid_format' ) {
-			$html = 'O formato da imagem enviada é invalido.';
+			$html = 'O formato da imagem enviada é inválido.';
 		}
 		return $html;
 	}

--- a/orbita.php
+++ b/orbita.php
@@ -52,16 +52,16 @@ function orbita_enqueue_styles() {
 add_action( 'wp_enqueue_scripts', 'orbita_enqueue_styles' );
 
 function orbita_preload_style ($preload_resources) {
-     $preload_resources[] = array(
-     		'href' => plugins_url() . '/orbita-'. ORBITA_VERSION .'/public/main.css?ver=' . ORBITA_VERSION,
-        'as' => 'style',
-        'type' => 'text/css',
-        'media' => 'all',
-    );
-    return $preload_resources;
- }
- add_filter('wp_preload_resources', 'orbita_preload_style');
- 
+	$preload_resources[] = array(
+		'href' => plugins_url() . '/orbita-'. ORBITA_VERSION .'/public/main.css?ver=' . ORBITA_VERSION,
+		'as' => 'style',
+		'type' => 'text/css',
+		'media' => 'all',
+	);
+	return $preload_resources;
+}
+add_filter('wp_preload_resources', 'orbita_preload_style');
+
 /**
  * Enqueue script file
  */
@@ -621,9 +621,9 @@ function orbita_link_options( $url = '', $title = '' ) {
 	if( $title && isset( $options['paywall'] ) ) {
 		$tags = [ 'es', 'en' ];
 		foreach ( $tags as $tag ){
-		   if ( str_contains( $title, '[' . $tag . ']' )){
+			if ( str_contains( $title, '[' . $tag . ']' )){
 				$options['translate'] = 'https://translate.google.com/translate?sl=' . $tag . '&tl=pt&hl=pt-BR&u=' . $options['paywall'];
-		   }
+			}
 		}
 	}
 
@@ -810,10 +810,10 @@ function orbita_form_shortcode() {
 	$html .= '      </div>';
 	$html .= '      <div class="orbita-form-control">';
 	$html .= '          <label for="orbita_post_attach">Imagem</label>';
-	$html .= '          <input type="file" id="orbita_post_attach" name="orbita_post_attach" accept=".jpg, .jpeg, .png, .gif">';
+	$html .= '          <input type="file" id="orbita_post_attach" name="orbita_post_attach" accept=".jpg, .jpeg, .png, .webp">';
 	$html .= '      </div>';
 	$html .= '      <div class="orbita-form-control">';
-	$html .= '          <p>Formatos aceitos: JPG, JPEG, PNG e GIF<br/>Tamanho máximo: '.size_format(wp_max_upload_size()).'</p>';
+	$html .= '          <p>Formatos aceitos: JPEG, PNG ou WEBP<br/>Tamanho máximo: '.size_format(wp_max_upload_size()).'</p>';
 	$html .= '      </div>';
 	$html .= '      <div class="orbita-form-control">';
 	$html .= '          <label for="orbita_post_content">Comentário</label>';

--- a/orbita.php
+++ b/orbita.php
@@ -1064,20 +1064,11 @@ function orbita_save_ogimage( $post_id ) {
 						case 'image/png':
 							$extension = 'png';
 							break;
-						case 'image/avif':
-							$extension = 'avif';
-							break;
-						case 'image/gif':
-							$extension = 'gif';
-							break;
 						case 'image/jpg':
 							$extension = 'jpg';
 							break;
 						case 'image/jpeg':
 							$extension = 'jpg';
-							break;
-						case 'image/svg+xml':
-							$extension = 'svg';
 							break;
 						case 'image/webp':
 							$extension = 'webp';

--- a/single-orbita.php
+++ b/single-orbita.php
@@ -19,6 +19,7 @@ get_header();
 			the_post();
 
 			$external_url = get_post_meta( get_the_id(), 'external_url', true );
+			$attach_file = get_post_meta( get_the_id(), 'attach_file', true );
 			$only_domain  = wp_parse_url( str_replace( 'www.', '', $external_url ), PHP_URL_HOST );
 			$count        = get_post_meta( get_the_id(), 'post_like_count', true );
 
@@ -82,7 +83,19 @@ get_header();
 								break;
 							}
 						}
-					} 
+					} else if( $attach_file == 1 ) {
+						if ( has_post_thumbnail() ) {
+							$large_image_url = wp_get_attachment_image_src( get_post_thumbnail_id(), 'large' );
+							$full_image_url = wp_get_attachment_image_src( get_post_thumbnail_id(), 'full' );
+							if ( ! empty( $large_image_url[0] ) ) {
+								printf( '<a target="_blank" href="%1$s" alt="%2$s">%3$s</a>',
+									esc_url( $full_image_url[0] ),
+									esc_attr( get_the_title() ),
+									get_the_post_thumbnail()
+								);
+							}
+						}	
+					}
 					esc_textarea( the_content() );
 				?>
 			</div>
@@ -94,7 +107,7 @@ get_header();
 		</article>
 			<?php
 			// If comments are open or we have at least one comment, load up the comment template.
-			if ( comments_open() || get_comments_number() ) : ?
+			if ( comments_open() || get_comments_number() ) :
 				comments_template();
 			endif;
 


### PR DESCRIPTION
**Ao abrir um Pull Request, marque com um X cada um dos items do checklist abaixo.**

### Checklist
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 14 (` * Version:         1.x.x`)
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 43 (`define( 'ORBITA_VERSION', '1.x.x' );`)

### Descrição

- Adicionado um campo para envio de imagens, limitado em `jpg/jpeg`, `png` ou `webp`, gif tem uma limitação de conversão pela possibilidade de gif animados
- Todas as imagens são convertidas para jpg com limite de largura e altura em `1200px`, o arquivo original é apagado
- Imagem adicionada é definida como `post_thumbnail` da postagem
- Arquivos salvos dentro de `wp-uploads/orbita/`