### PR TITLE
Remove a versão da chamada do CSS

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         1.10.4.3
+ * Version:         1.10.5
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3

--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         1.10.4
+ * Version:         1.10.4.3
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define plugin version constant
  */
-define( 'ORBITA_VERSION', '1.10.4' );
+define( 'ORBITA_VERSION', '1.10.4.3' );
 define( 'ORBITA_IMAGE_MAX_SIZE', '10' ); // MB
 
 /**
@@ -54,7 +54,7 @@ add_action( 'wp_enqueue_scripts', 'orbita_enqueue_styles' );
 
 function orbita_preload_style ($preload_resources) {
 	$preload_resources[] = array(
-		'href' => plugins_url() . '/orbita-'. ORBITA_VERSION .'/public/main.css?ver=' . ORBITA_VERSION,
+		'href' => plugins_url() . '/orbita/public/main.css?ver=' . ORBITA_VERSION,
 		'as' => 'style',
 		'type' => 'text/css',
 		'media' => 'all',

--- a/orbita.php
+++ b/orbita.php
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Define plugin version constant
  */
-define( 'ORBITA_VERSION', '1.10.4.3' );
+define( 'ORBITA_VERSION', '1.10.5' );
 define( 'ORBITA_IMAGE_MAX_SIZE', '10' ); // MB
 
 /**


### PR DESCRIPTION
### Checklist
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 14 (` * Version:         1.x.x`)
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 43 (`define( 'ORBITA_VERSION', '1.x.x' );`)

### Descrição

Conforme conversado em outro PR, estou renomeando o diretório e o `*.zip* de novas versões do Órbita antes de subi-las no servidor.

Com isso, o diretório do Órbita dentro do `wp-content/plugins/` deixa de ter a versão (de `orbita-1.10.4.3` para `orbita`), o que exige que a chamada do arquivo `*.css` não tenha a versão no caminho, dentro do `orbita.php`.