### PR TITLE
Otimização do WP_Query

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -424,6 +424,10 @@ function orbita_ranking_shortcode( $atts = array(), $content = null, $tag = '' )
 			'after' => $orbita_rank_atts['days'] . ' days ago',
 		),
 		'post__not_in'   => get_option( 'sticky_posts' ),
+		'no_found_rows'  => true,
+		'update_post_meta_cache'  => false,
+		'update_post_term_cache'  => false,
+		'update_menu_item_cache'  => false,
 	);
 
 	$orbita_posts_array = orbita_ranking_calculator(
@@ -441,6 +445,10 @@ function orbita_ranking_shortcode( $atts = array(), $content = null, $tag = '' )
 			),
 		),
 		'post__not_in'  => get_option( 'sticky_posts' ),
+		'no_found_rows'  => true,
+		'update_post_meta_cache'  => false,
+		'update_post_term_cache'  => false,
+		'update_menu_item_cache'  => false,
 	);
 
 	$blog_posts_array = orbita_ranking_calculator(
@@ -493,6 +501,10 @@ function orbita_posts_shortcode( $atts = array(), $content = null, $tag = '' ) {
 		'posts_per_page' => 10,
 		'paged'          => $paged,
 		'post__not_in'   => get_option( 'sticky_posts' ),
+		'no_found_rows'  => true,
+		'update_post_meta_cache'  => false,
+		'update_post_term_cache'  => false,
+		'update_menu_item_cache'  => false,
 	);
 
 	if ( true === $orbita_posts_atts['latest'] ) {


### PR DESCRIPTION
**Ao abrir um Pull Request, marque com um X cada um dos items do checklist abaixo.**

### Checklist
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 14 (` * Version:         1.x.x`)
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 43 (`define( 'ORBITA_VERSION', '1.x.x' );`)

### Descrição

Topei com este post: https://www.spacedmonkey.com/2025/04/14/enhancing-wp_query-performance-in-wordpress/

Acrescentei alguns parâmetros que pareceram fazer sentido:

```php
'no_found_rows'  => true,
'update_post_meta_cache'  => false,
'update_post_term_cache'  => false,
'update_menu_item_cache'  => false,
```

Monitorei os resultados no staging, na página `/orbita`, com o plugin Query Monitor. Principais diferenças:

* Redução das consultas ao banco de dados (~14 para ~7).
* Aumento da taxa de acertos do cache de objetos (~94% para ~99%).

Não sei dizer se os parâmetros adicionados trazem efeitos colaterais indesejados.