### PR TITLE
Ajustando redirecionamento para o Marreta

### DIFF
--- a/orbita.php
+++ b/orbita.php
@@ -11,7 +11,7 @@
  * Plugin Name:     Órbita
  * Plugin URI:      https://gnun.es
  * Description:     Órbita é o plugin para criar um sistema Hacker News-like para o Manual do Usuário
- * Version:         2.0
+ * Version:         2.0.1
  * Author:          Gabriel Nunes
  * Author URI:      https://gnun.es
  * License:         GPL v3
@@ -41,7 +41,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Define plugin version constant
  */
 
-define( 'ORBITA_VERSION', '2.0' );
+define( 'ORBITA_VERSION', '2.0.1' );
 define( 'ORBITA_IMAGE_MAX_SIZE', '10' ); // MB
 
 /**
@@ -627,7 +627,7 @@ function orbita_link_options( $url = '', $title = '' ) {
 
 		foreach ( $publishers as $publisher ) {
 			if ( preg_match("~" . preg_quote( $publisher['url'], "~" ) . "~i", $url ) ) {
-				$options['paywall'] = $publisher['paywall'] . $url;
+				$options['paywall'] = $publisher['paywall'] . urlencode($url);
 			}
 		}
 	}


### PR DESCRIPTION
**Ao abrir um Pull Request, marque com um X cada um dos items do checklist abaixo.**

### Checklist
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 14 (` * Version:         1.x.x`)
- [x] Atualização da versão do plugin no arquivo `orbita.php` na linha 43 (`define( 'ORBITA_VERSION', '1.x.x' );`)

### Descrição

Atualmente o redirecionamento dos links dos _publishers_ para remoção do _paywall_ usando o Marreta está retornando como URL inválida (gif abaixo). Acabei descobrindo que o Marreta apenas aceita URLs codificadas (encoded), por isso retorna o URL.

![Screen Recording 2026-02-04 at 16 35 35](https://github.com/user-attachments/assets/b4da2600-30a0-4af7-8ea7-186df0b231ea)
_link usado: https://manualdousuario.net/orbita-post/como-a-pf-acessou-celular-apreendido-de-vorcaro-mesmo-sem-senha/_

Nesse PR, ajusta o redirecionamento para o Marreta com a URL codificada usando a função `urlencode`. 

![Screen Recording 2026-02-04 at 16 38 54](https://github.com/user-attachments/assets/d7fdd875-c96a-4f99-b013-0fb93eaa70f4)
_redirecionamento funcionando corretamente_